### PR TITLE
update correct KMS key alias in bash script

### DIFF
--- a/ebs/Bash/enable-ebs-encryption-for-account.sh
+++ b/ebs/Bash/enable-ebs-encryption-for-account.sh
@@ -5,7 +5,7 @@ aws ec2 enable-ebs-encryption-by-default
 
 aws ec2 get-ebs-default-kms-key-id
 
-EBS_CMK_ARN=$(aws kms describe-key --key-id 'alias/EC2EncryptionAtRestCMKAlias' |jq --raw-output '.KeyMetadata.Arn')
+EBS_CMK_ARN=$(aws kms describe-key --key-id 'alias/EC2EncryptionAtRestKeyAlias' |jq --raw-output '.KeyMetadata.Arn')
 
 aws ec2 modify-ebs-default-kms-key-id --kms-key-id "$EBS_CMK_ARN"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed the key name accordingly to what is set in the cloudformation stack when the key alias is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
