### PR TITLE
fix: Add DeletionPolicy Retain to KMS key to prevent accidental data loss on stack deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ The sample solution can be deployed using the AWS CloudFormation template, which
 
 Once the resources are remediated, ensure preventive enforcement via Service Control Policies to deny EC2 instance and volume creation in the future without encryption.
 
+### Important: KMS Key Deletion Protection (EBS)
+
+The `Stack1.yaml` template includes `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain` on the KMS key resource (`EBSEncryptionKey`). This ensures the KMS key is **not** scheduled for deletion when the CloudFormation stack is removed or updated.
+
+**Why this matters:** The KMS key created by Stack1 encrypts all EBS volumes processed by the SSM Automation in Stack2. If the key is deleted, all encrypted volumes become permanently unrecoverable after the 30-day KMS pending deletion window. Because the automation deletes the intermediate snapshots, there is no recovery path once the key is gone.
+
+**For non-production environments:** If you need CloudFormation to fully clean up all resources (including the KMS key) when tearing down the stack, you can remove or modify the following properties on the `EBSEncryptionKey` resource in `ebs/CloudFormation/Stack1.yaml`:
+
+```yaml
+# To allow full cleanup on stack delete (non-production only), remove these lines:
+DeletionPolicy: Retain
+UpdateReplacePolicy: Retain
+```
+
 ## Automatically remediate unencrypted RDS Instances and Clusters using customer KMS keys
 
 This [sample](rds) describes how to automatically remediate unencrypted Amazon RDS Instances and Clusters. Amazon RDS encrypted DB instances provide an additional layer of data protection by securing your data from unauthorized access to the underlying storage. You can use Amazon RDS encryption to increase data protection of your applications deployed in the cloud, and to fulfill compliance requirements for encryption at rest.

--- a/ebs/CloudFormation/Stack1.yaml
+++ b/ebs/CloudFormation/Stack1.yaml
@@ -132,6 +132,8 @@ Resources:
         Version: "2012-10-17"
   EBSEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy : Retain
+    UpdateReplacePolicy : Retain
     Properties: 
       Description: Key used for encryption EBS volumes
       Enabled: True


### PR DESCRIPTION
### Problem
When a user deletes the CloudFormation stack created by Stack1.yaml, the KMS key (`EBSEncryptionKey`) is automatically scheduled for deletion. Since this key is used to encrypt EBS volumes via the SSM Automation in Stack2, deleting the stack renders all encrypted volumes permanently unrecoverable after the 30-day KMS key pending deletion window.

### Root Cause
The `EBSEncryptionKey` resource in Stack1.yaml does not have a `DeletionPolicy` attribute. CloudFormation's default behavior is to delete all resources when a stack is deleted, including calling `ScheduleKeyDeletion` on KMS keys.

### Fix
- Added `DeletionPolicy: Retain` to the `EBSEncryptionKey` resource to ensure the KMS key is preserved even if the stack is deleted.
- Added `UpdateReplacePolicy: Retain` to protect the key during stack updates that would replace the resource.

### Testing
Replicated the issue in a test account:
1. Deployed Stack1 and Stack2
2. Launched EC2 instance, triggered SSM Automation to encrypt volume
3. Deleted the stack - confirmed KMS key was scheduled for deletion (without the fix)
4. With the fix applied, the KMS key persists after stack deletion

